### PR TITLE
Darwin doen't have some constants

### DIFF
--- a/zebra_darwin.go
+++ b/zebra_darwin.go
@@ -1,5 +1,3 @@
-// +build !darwin
-
 // Copyright (C) 2014, 2015 Nippon Telegraph and Telephone Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -423,23 +421,8 @@ func intfflag2string(flag uint64) string {
 	if flag&syscall.IFF_ALLMULTI > 0 {
 		ss = append(ss, "ALLMULTI")
 	}
-	if flag&syscall.IFF_MASTER > 0 {
-		ss = append(ss, "MASTER")
-	}
-	if flag&syscall.IFF_SLAVE > 0 {
-		ss = append(ss, "SLAVE")
-	}
 	if flag&syscall.IFF_MULTICAST > 0 {
 		ss = append(ss, "MULTICAST")
-	}
-	if flag&syscall.IFF_PORTSEL > 0 {
-		ss = append(ss, "PORTSEL")
-	}
-	if flag&syscall.IFF_AUTOMEDIA > 0 {
-		ss = append(ss, "AUTOMEDIA")
-	}
-	if flag&syscall.IFF_DYNAMIC > 0 {
-		ss = append(ss, "DYNAMIC")
 	}
 	//	if flag&syscall.IFF_LOWER_UP > 0 {
 	//		ss = append(ss, "LOWER_UP")


### PR DESCRIPTION
OSX Yosemite doesn't have some platform-dependent constants like this:

``` zsh
gozebra $ go build
# _/Users/koji/darwin/tmp/gozebra
./zebra.go:424: undefined: syscall.IFF_MASTER
./zebra.go:427: undefined: syscall.IFF_SLAVE
./zebra.go:433: undefined: syscall.IFF_PORTSEL
./zebra.go:436: undefined: syscall.IFF_AUTOMEDIA
./zebra.go:439: undefined: syscall.IFF_DYNAMIC
zsh: exit 2     go build
gozebra $ uname -a
Darwin kojimae 14.4.0 Darwin Kernel Version 14.4.0: Thu May 28 11:35:04 PDT 2015; root:xnu-2782.30.5~1/RELEASE_X86_64 x86_64
```
- syscall.IFF_MASTER
- syscall.IFF_SLAVE
- syscall.IFF_PORTSEL
- syscall.IFF_AUTOMEDIA
- syscall.IFF_DYNAMIC

I'd think that dedicated source file could be an option only when $GOOS == darwin.
